### PR TITLE
Fix incorrect use of `pathdiff` (remove file name before call)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,17 +37,6 @@ pub fn start(args: Vec<String>) -> IDFC<()> {
 	let cmd = cmd_replace_aliases(cmd);
 
 	match cmd {
-		"ts"		=> {
-			// testing stuff
-			let mut path1 = env::current_dir()?;
-			path1.push("test1");
-
-			let diff =
-				pathdiff::diff_paths(path1, get_closest_index().unwrap());
-
-			dbg!(&diff);
-		},
-
 		"create"	=> {
 			assert_argc(args, &[0, 1]);
 


### PR DESCRIPTION
Turns out, the actual file names can't be a part of the parameters. Otherwise, it assumes the name is just another directory in the path.

This fix checks the file name before it calls the function from `pathdiff`. Then, it just adds that on at the end. The only downside is that folders probably won't work properly with `yx` anymore, but we can just improve and add that as a feature later.